### PR TITLE
Merchant items nigel fix

### DIFF
--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -1,7 +1,7 @@
 class MerchantItemsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
-    @merchant_items = @merchant.items
+    @merchant_items = @merchant.items_ordered_by_most_recently_updated_at
   end
 
   def show

--- a/app/controllers/merchant_items_controller.rb
+++ b/app/controllers/merchant_items_controller.rb
@@ -32,8 +32,15 @@ class MerchantItemsController < ApplicationController
 
   def create
     merchant = Merchant.find(params[:merchant_id])
-    @item = merchant.items.create!(item_params)
-    redirect_to merchant_items_path(merchant.id)
+    item = merchant.items.new(item_params)
+    if item.save
+      redirect_to merchant_items_path(merchant.id)
+      flash[:notice] = 'Item has been created!'
+    else
+      flash[:alert] = "Fields cannot be blank"
+      @item = merchant.items.new(item_params)
+      render :new
+    end
   end
 
   private

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -15,4 +15,8 @@ class Merchant < ApplicationRecord
         .order("revenue desc")
         .limit(5)
   end
+
+  def items_ordered_by_most_recently_updated_at
+    self.items.order(updated_at: :desc)
+  end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -189,34 +189,6 @@ RSpec.describe 'The Merchant Items Index page', type: :feature do
       expect(page).to have_field('Description')
       expect(page).to have_field('Current Selling Price')
     end
-
-    it "When I fill out the form and hit 'submit I am taken back to the items index page" do
-      visit "/merchants/#{merchant1.id}/items/new"
-
-      fill_in("Name", with: "Bubble Machine")
-      fill_in("Description", with: "Serotonin Maker")
-      fill_in("Current Selling Price", with: 2500)
-
-      click_button("Submit")
-
-      expect(current_path).to eq(merchant_items_path(merchant1.id))
-    end
-
-    it "I see the item I just created in the list of items and a status of disabled" do
-      visit "/merchants/#{merchant1.id}/items/new"
-
-      fill_in("Name", with: "Bubble Machine")
-      fill_in("Description", with: "Serotonin Maker")
-      fill_in("Current Selling Price", with: 2500)
-
-      click_button("Submit")
-
-      item = Item.last
-      within "#item_#{item.id}" do
-        expect(page).to have_link("Bubble Machine")
-        expect(page).to have_content("Status: disabled")
-      end
-    end
   end
 
   describe "two sections, one for enabled items, one for disabled items" do #us10

--- a/spec/features/merchants/items/new_spec.rb
+++ b/spec/features/merchants/items/new_spec.rb
@@ -1,0 +1,121 @@
+require 'rails_helper'
+
+RSpec.describe "merchant items new form" do
+  let!(:merchant1) { Merchant.create!(name: "Billy's Butters") }
+  it "When I fill out the form and hit 'submit I am taken back to the items index page" do
+    visit "/merchants/#{merchant1.id}/items/new"
+
+    fill_in("Name", with: "Bubble Machine")
+    fill_in("Description", with: "Serotonin Maker")
+    fill_in("Current Selling Price", with: 2500)
+
+    click_button("Submit")
+
+    expect(current_path).to eq(merchant_items_path(merchant1.id))
+  end
+
+  it "I see the item I just created in the list of items and a status of disabled" do
+    visit "/merchants/#{merchant1.id}/items/new"
+
+    fill_in("Name", with: "Bubble Machine")
+    fill_in("Description", with: "Serotonin Maker")
+    fill_in("Current Selling Price", with: 2500)
+
+    click_button("Submit")
+
+    item = Item.last
+    within "#item_#{item.id}" do
+      expect(page).to have_link("Bubble Machine")
+      expect(page).to have_content("Status: disabled")
+    end
+
+    expect(page).to have_content('Item has been created!')
+  end
+
+  describe "If any fields are left blank when creating a new merchant item and
+  I click submit" do
+    describe "If name is blank" do
+      it 'I stay on the merchant item new form page with the form pre filled with any filled in info' do
+        visit "/merchants/#{merchant1.id}/items/new"
+  
+        fill_in("Description", with: "Serotonin Maker")
+        fill_in("Current Selling Price", with: 2500)
+        click_button("Submit")
+  
+        expect(page).to have_field("Name", with: "")
+        expect(page).to have_field("Description", with: "Serotonin Maker")
+        expect(page).to have_field("Current Selling Price", with: 2500)
+
+        expect(page).to have_content("Fields cannot be blank")
+      end
+    end
+
+    describe "If Description is blank" do
+      it 'I stay on the merchant item new form page with the form pre filled with any filled in info' do
+        visit "/merchants/#{merchant1.id}/items/new"
+        
+        fill_in("Name", with: "Bubble Machine")
+        fill_in("Current Selling Price", with: 2500)
+        click_button("Submit")
+  
+        expect(page).to have_field("Name", with: "Bubble Machine")
+        expect(page).to have_field("Description", with: "")
+        expect(page).to have_field("Current Selling Price", with: 2500)
+
+        expect(page).to have_content("Fields cannot be blank")
+      end
+    end
+
+    describe "If Current Selling Price is blank" do
+      it 'I stay on the merchant item new form page with the form pre filled with any filled in info' do
+        visit "/merchants/#{merchant1.id}/items/new"
+        
+        fill_in("Name", with: "Bubble Machine")
+        fill_in("Description", with: "Serotonin Maker")
+        click_button("Submit")
+        
+        expect(page).to have_field("Name", with: "Bubble Machine")
+        expect(page).to have_field("Description", with: "Serotonin Maker")
+        expect(page).to have_field("Current Selling Price", with: "")
+
+        expect(page).to have_content("Fields cannot be blank")
+      end
+    end
+
+    describe "If all fields are blank" do
+      it 'I stay on the merchant item new form page with the form pre filled with any filled in info' do
+        visit "/merchants/#{merchant1.id}/items/new"
+        
+        click_button("Submit")
+        
+        expect(page).to have_field("Name", with: "")
+        expect(page).to have_field("Description", with: "")
+        expect(page).to have_field("Current Selling Price", with: "")
+
+        expect(page).to have_content("Fields cannot be blank")
+      end
+    end
+
+    describe "If I make a second attempt while successfully completing each field" do
+      it "The item is created and we are taken back to the merchant items index with the new item present" do
+        visit "/merchants/#{merchant1.id}/items/new"
+        
+        click_button("Submit")
+
+        fill_in("Name", with: "Bubble Machine")
+        fill_in("Description", with: "Serotonin Maker")
+        fill_in("Current Selling Price", with: 2500)
+
+        click_button("Submit")
+
+        item = Item.last
+        within "#item_#{item.id}" do
+          expect(page).to have_link("Bubble Machine")
+          expect(page).to have_content("Status: disabled")
+        end
+
+        expect(page).to have_content('Item has been created!')
+      end
+    end
+  end
+end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -69,5 +69,27 @@ RSpec.describe Merchant, type: :model do
         expect(merchant1.top_five_items_ordered).to eq([item1, item2, item3, item4, item6])
       end
     end
+
+    describe "#items_ordered_by_most_recently_updated_at" do
+      it 'returns an array of a merchants items ordered by their creation time' do
+        merchant1 = Merchant.create!(name: "Harvey")
+        merchant2 = Merchant.create!(name: "John")
+        item3 = merchant1.items.create!(name: "Saw", description:"Cut things", unit_price: 2000)
+        item1 = merchant1.items.create!(name: "Hammer", description:"Hit things", unit_price: 1200)
+        item2 = merchant1.items.create!(name: "Nail", description:"Secure things", unit_price: 22)
+
+        merchant2.items << item1
+        merchant2.items << item2
+        merchant2.items << item3
+
+        expect(item3.created_at).to be < item1.created_at
+        expect(item1.created_at).to be < item2.created_at
+
+        expect(item3.updated_at).to be > item2.updated_at
+        expect(item2.updated_at).to be > item1.updated_at
+
+        expect(merchant2.items_ordered_by_most_recently_updated_at).to eq([item3, item2, item1])
+      end
+    end
   end
 end


### PR DESCRIPTION
Added conditional paths to the merchant items controller create action

- flash messages added for success and failure paths
- new form prepopulates form fields with what information was written before failed creation attempt

Added merchant model method for ordering items based on updated_at

- This is used in the merchant items index page for displaying items in a predictable order after being disabled/enabled
- also useful for newly created items to go to the top of the list