### PR TITLE
GitHub api nigel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 gem 'httparty'
+gem 'json'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json (2.3.0)
     launchy (2.5.2)
       addressable (~> 2.8)
     listen (3.1.5)
@@ -255,6 +256,7 @@ DEPENDENCIES
   hirb
   httparty
   jbuilder (~> 2.5)
+  json
   launchy
   listen (>= 3.0.5, < 3.2)
   orderly

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,20 +2,11 @@ class ApplicationController < ActionController::Base
   before_action :github 
 
   def github
+    # Usernames and User Commit Totals
+    @users = Rails.cache.fetch('users', expires_in: 45.minutes) { GithubFacade.users }
     # Repo Name
-    repo = GithubService.new(EndPoints.repo)
-    @repo_name = RepositoryName.new(repo.data).name
-    
-    # Contributor Names
-    contributors = GithubService.new(EndPoints.contributors)
-    @contributor_names = Contributors.new(contributors.data).contributors
-    
-    # Commit Count 
-    commits = GithubService.new(EndPoints.commits) 
-    @commits_count = RepositoryCommits.new(commits.data).commits
-    
+    @repo = Rails.cache.fetch('repo', expires_in: 45.minutes) { GithubFacade.repo }
     # Pull Request Count
-    pulls = GithubService.new(EndPoints.pulls("closed"))
-    @pr_count = RepositoryPullRequests.new(pulls.data).count
+    @merged_pulls = Rails.cache.fetch('merged_pulls', expires_in: 45.minutes) { GithubFacade.merged_pulls }
   end
 end

--- a/app/facades/github_facade.rb
+++ b/app/facades/github_facade.rb
@@ -1,0 +1,18 @@
+class GithubFacade
+  def self.users
+    json = GithubService.users
+    json.map do |data|
+      User.new(data) unless ["BrianZanti","timomitchel","scottalexandra","cjsim89","jamisonordway", "mikedao"].include?(data[:author][:login])
+    end.compact
+  end
+
+  def self.repo
+    json = GithubService.repo
+    Repo.new(json)
+  end
+
+  def self.merged_pulls
+    json = GithubService.merged_pulls
+    PullRequests.new(json)
+  end
+end

--- a/app/poros/pull_requests.rb
+++ b/app/poros/pull_requests.rb
@@ -1,0 +1,6 @@
+class PullRequests
+  attr_reader :count
+  def initialize(data)
+    @count = data.count
+  end
+end

--- a/app/poros/repo.rb
+++ b/app/poros/repo.rb
@@ -1,0 +1,6 @@
+class Repo
+  attr_reader :name
+  def initialize(data)
+    @name = data[:name]
+  end
+end

--- a/app/poros/user.rb
+++ b/app/poros/user.rb
@@ -1,0 +1,8 @@
+class User
+  attr_reader :username, :commit_total
+
+  def initialize(data)
+    @username = data[:author][:login]
+    @commit_total = data[:total]
+  end
+end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -1,73 +1,18 @@
-require 'json'
-require 'httparty'
-require 'pry'
-
-class EndPoints
-  def self.repo
-    "https://api.github.com/repos/pocketzs/little-esty-shop"
-  end
-
-  def self.contributors
-    "https://api.github.com/repos/Pocketzs/little-esty-shop/contributors" #{/collaborator}
-  end
-
-  def self.collaborators
-    "https://api.github.com/repos/Pocketzs/little-esty-shop/collaborators" #{/collaborator}
-  end
-
-  def self.commits #(person)
-    "https://api.github.com/repos/Pocketzs/little-esty-shop/commits/" #?author=#{person}" #{/sha}
-  end
-
-  def self.pulls(state)
-    "https://api.github.com/repos/Pocketzs/little-esty-shop/pulls?state=#{state}"
-  end
-end
-
 class GithubService
-  attr_reader :data
+  def self.repo
+    get_url
+  end
 
-  def initialize(url)
-    @data = get_url(url)
+  def self.users
+    get_url("/stats/contributors")
   end
   
-  def get_url(url)
-    response = HTTParty.get(url)
-    parsed_info(response)
+  def self.merged_pulls
+    get_url("/pulls?state=closed&per_page=100")
   end
 
-  def parsed_info(response)
+  def self.get_url(path = nil)
+    response = HTTParty.get("https://api.github.com/repos/pocketzs/little-esty-shop#{path}")
     JSON.parse(response.body, symbolize_names: true)
-  end
-end
-
-class Contributors
-  attr_reader :contributors
-  def initialize(data)
-    @contributors = data.map do |contributor|
-      contributor = contributor[:login] 
-    end
-  @contributors -= ["BrianZanti","timomitchel","scottalexandra","cjsim89","jamisonordway", "mikedao"]
-  end
-end
-
-class RepositoryName
-  attr_reader :name
-  def initialize(data)
-    @name = data[:name]
-  end
-end
-
-class RepositoryCommits
-  attr_reader :commits
-  def initialize(data)
-    @commits = data.count
-  end
-end
-
-class RepositoryPullRequests
-  attr_reader :count
-  def initialize(data)
-    @count = data.count
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,12 +16,13 @@
     <%= yield %>
   <hr>
   <div id="github-stats">
-    Repository Name: <%= @repo_name %><br>
-    Contributor Names:<br> <% @contributor_names.each do |name| %>
-      <%= name %>
-    <% end %><br>
-    Commits Count: <%= @commits_count %><BR>
-    PR Count: <%= @pr_count %><br>
+    Repository Name: <%= @repo.name %><br>
+    Contributors:<br> <% @users.each do |user| %>
+      <div id=<%= "user-#{user.username}" %>>
+      Username: <%= user.username %> | Total Commits: <%= user.commit_total %> <br>
+      </div>
+    <% end %>
+    Merged Pull Requests: <%= @merged_pulls.count %><br>
   </div>
   </body>
 </html>

--- a/spec/facades/github_facade_spec.rb
+++ b/spec/facades/github_facade_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe GithubFacade do
+  describe 'class methods' do
+    describe '.users' do
+      it 'returns an array of User objects' do
+        expect(GithubFacade.users).to all be_a User
+      end
+    end
+
+    describe '.repo' do
+      it 'returns a Repo object with a name' do
+        expect(GithubFacade.repo).to be_a Repo
+        expect(GithubFacade.repo.name).to be_a String
+      end
+    end
+
+    describe '.merged_pulls' do
+      it 'returns a PullRequests object with a an integer count of closed prs' do
+        expect(GithubFacade.merged_pulls).to be_a PullRequests
+        expect(GithubFacade.merged_pulls.count).to be_an Integer
+      end
+    end
+  end
+end

--- a/spec/poros/pull_request_spec.rb
+++ b/spec/poros/pull_request_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe PullRequests do
+  it 'exists' do
+    data = [{state:'closed'}, {state:'closed'}, {state:'closed'}, {state:'closed'}, {state:'closed'}]
+
+    pr = PullRequests.new(data)
+
+    expect(pr).to be_a PullRequests
+    expect(pr.count).to eq 5
+  end
+end

--- a/spec/poros/repo_spec.rb
+++ b/spec/poros/repo_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Repo do
+  it 'exists' do
+    data = {
+      name: 'little-esty-shop'
+    }
+
+    repo = Repo.new(data)
+
+    expect(repo).to be_a Repo
+    expect(repo.name).to eq 'little-esty-shop'
+  end
+end

--- a/spec/poros/user_spec.rb
+++ b/spec/poros/user_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.describe User do
+  it "exists" do
+    data = {
+      author: { login: "Leslie Knope" },
+      total: "1"
+    }
+
+    user = User.new(data)
+
+    expect(user).to be_a User
+    expect(user.username).to eq("Leslie Knope")
+    expect(user.commit_total).to eq("1")
+  end
+end

--- a/spec/services/github_service_spec.rb
+++ b/spec/services/github_service_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe GithubService do
+  describe 'class methods' do
+    describe '.users' do
+      it 'returns repo stats contributors data with username and commit totals' do
+        search = GithubService.users
+        expect(search).to be_an Array
+        user_stats = search.first
+        expect(user_stats[:total]).to be_an Integer
+        expect(user_stats[:author][:login]).to be_a String
+      end
+    end
+
+    describe '.repo' do
+      it 'returns the repo data including repo name' do
+        search = GithubService.repo
+        expect(search).to be_a Hash
+        expect(search[:name]).to be_a String
+      end
+    end
+
+    describe '.merged_pulls' do
+      it 'it returns data for closed pull requests' do
+        search = GithubService.merged_pulls
+        expect(search).to be_an Array
+        expect(search).to all include(state: 'closed')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Refactored github_services to live among several poros files and controller refactored with github_facade

different api urls chosen to consolidate username and commit totals data into a single call

low level caching added to prevent api over call during development runs

spec/model tests all passing but coverage at 99.13% missing item model test
<img width="559" alt="image" src="https://user-images.githubusercontent.com/110859604/212049295-d70dae7d-8cf9-4775-893b-c0dc0e389c7b.png">
spec/features tests all passing but coverage at 99.8% missing update action sad path test
<img width="516" alt="image" src="https://user-images.githubusercontent.com/110859604/212050652-3251ae57-4fbd-4b23-8ff3-1db7d124687b.png">
